### PR TITLE
Fix build failure due to C++11's explicit ctor of std::unordered_map

### DIFF
--- a/src/Console.cpp
+++ b/src/Console.cpp
@@ -25,7 +25,7 @@ namespace CppReadline {
 
         ::std::string       greeting_;
         // These are hardcoded commands. They do not do anything and are catched manually in the executeCommand function.
-        RegisteredCommands  commands_   = {};
+        RegisteredCommands  commands_;
         HISTORY_STATE*      history_    = nullptr;
 
         Impl(::std::string const& greeting) : greeting_{greeting} {}


### PR DESCRIPTION
fixes issue #3
